### PR TITLE
Fix missing dependency for build

### DIFF
--- a/app-main/package-lock.json
+++ b/app-main/package-lock.json
@@ -17,7 +17,8 @@
                 "next-auth": "^4.24.11",
                 "next-secure-headers": "^2.2.0",
                 "react": "^18.2.0",
-                "react-dom": "^18.2.0"
+                "react-dom": "^18.2.0",
+                "lucide-react": "^0.515.0"
             },
             "devDependencies": {
                 "@tailwindcss/aspect-ratio": "^0.4.2",
@@ -2546,6 +2547,15 @@
             },
             "peerDependencies": {
                 "react": "^18.3.1"
+            }
+        },
+        "node_modules/lucide-react": {
+            "version": "0.515.0",
+            "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.515.0.tgz",
+            "integrity": "sha512-Sy7bY0MeicRm2pzrnoHm2h6C1iVoeHyBU2fjdQDsXGP51fhkhau1/ZV/dzrcxEmAKsxYb6bGaIsMnGHuQ5s0dw==",
+            "license": "ISC",
+            "peerDependencies": {
+                "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/read-cache": {

--- a/app-main/package.json
+++ b/app-main/package.json
@@ -22,7 +22,8 @@
         "next-auth": "^4.24.11",
         "next-secure-headers": "^2.2.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "lucide-react": "^0.515.0"
     },
     "devDependencies": {
         "@tailwindcss/aspect-ratio": "^0.4.2",


### PR DESCRIPTION
## Summary
- add lucide-react dependency to frontend app package

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685be09b35e4832ca703487c3f38dcd4