### PR TITLE
Fix Next.js route export

### DIFF
--- a/app-main/app/api/auth/[...nextauth]/route.ts
+++ b/app-main/app/api/auth/[...nextauth]/route.ts
@@ -1,6 +1,5 @@
-import NextAuth, { NextAuthOptions, AuthOptions, Session } from "next-auth";
-import AzureADProvider from "next-auth/providers/azure-ad";
-import { JWT } from "next-auth/jwt";
+import NextAuth, { AuthOptions } from "next-auth";
+import { authOptions } from "../../../../lib/auth";
 
 /**
  * Example scope:
@@ -11,70 +10,6 @@ import { JWT } from "next-auth/jwt";
  *   scope: "openid profile email offline_access api://<YOUR_API_CLIENT_ID>/access_as_user"
  */
 
-export const authOptions: NextAuthOptions = {
-  providers: [
-    AzureADProvider({
-      clientId: process.env.NEXT_PUBLIC_AZURE_AD_CLIENT_ID!,      // <--- Frontend App’s Client ID
-      clientSecret: process.env.AZURE_AD_CLIENT_SECRET!,          // <--- App secret
-      tenantId: process.env.NEXT_PUBLIC_AZURE_AD_TENANT_ID!,      // <--- Your tenant (directory) ID
-      checks: ["pkce", "state"],
-
-      // IMPORTANT: Add the custom scope for the Django API
-      authorization: {
-        params: {
-          // By default: "openid profile email offline_access"
-          // Add your custom API scope here
-          scope:
-            "openid profile email offline_access api://ccd5ce0d-5f7a-43cf-bbb8-82c9cb822f12/access_as_user",
-        },
-      },
-    }),
-  ],
-
-  // Use JWT-based sessions so that we can store the access token
-  session: {
-    strategy: "jwt",
-  },
-
-  // This should be a long, random string used to sign cookies etc.
-  secret: process.env.NEXTAUTH_SECRET,
-
-  callbacks: {
-    /**
-     * The "jwt" callback runs whenever a token is created or updated.
-     * We save the "access_token" returned by AzureAD into "token.accessToken".
-     */
-    async jwt({ token, account }: { token: JWT; account?: any }) {
-      if (account?.access_token) {
-        token.accessToken = account.access_token;
-      }
-      return token;
-    },
-
-    /**
-     * The "session" callback runs whenever a session is checked/created.
-     * We attach "token.accessToken" to "session.accessToken" so the client can use it.
-     */
-    async session({ session, token }: { session: Session; token: JWT }) {
-      // Put the Azure AD access token on the session, so you can do:
-      // fetch("...", { headers: { Authorization: `Bearer ${session.accessToken}` }})
-      return {
-        ...session,
-        accessToken: token.accessToken,
-      };
-    },
-
-    /**
-     * Optional: Force user to land on /welcome after sign in
-     */
-    async redirect({ url, baseUrl }) {
-      return `${baseUrl}/welcome`;
-    },
-  },
-
-  // For debugging in development:
-  debug: true,
-};
 
 const handler = NextAuth(authOptions as AuthOptions);
 export { handler as GET, handler as POST };

--- a/app-main/app/protected/layout.tsx
+++ b/app-main/app/protected/layout.tsx
@@ -1,5 +1,5 @@
 import { getServerSession } from "next-auth";
-import { authOptions } from "../api/auth/[...nextauth]/route";
+import { authOptions } from "../../lib/auth";
 import { redirect } from "next/navigation";
 
 export default async function ProtectedLayout({

--- a/app-main/lib/auth.ts
+++ b/app-main/lib/auth.ts
@@ -1,0 +1,42 @@
+import { NextAuthOptions, AuthOptions, Session } from "next-auth";
+import AzureADProvider from "next-auth/providers/azure-ad";
+import { JWT } from "next-auth/jwt";
+
+export const authOptions: NextAuthOptions = {
+  providers: [
+    AzureADProvider({
+      clientId: process.env.NEXT_PUBLIC_AZURE_AD_CLIENT_ID!,
+      clientSecret: process.env.AZURE_AD_CLIENT_SECRET!,
+      tenantId: process.env.NEXT_PUBLIC_AZURE_AD_TENANT_ID!,
+      checks: ["pkce", "state"],
+      authorization: {
+        params: {
+          scope:
+            "openid profile email offline_access api://ccd5ce0d-5f7a-43cf-bbb8-82c9cb822f12/access_as_user",
+        },
+      },
+    }),
+  ],
+  session: {
+    strategy: "jwt",
+  },
+  secret: process.env.NEXTAUTH_SECRET,
+  callbacks: {
+    async jwt({ token, account }: { token: JWT; account?: any }) {
+      if (account?.access_token) {
+        token.accessToken = account.access_token;
+      }
+      return token;
+    },
+    async session({ session, token }: { session: Session; token: JWT }) {
+      return {
+        ...session,
+        accessToken: token.accessToken,
+      };
+    },
+    async redirect({ url, baseUrl }) {
+      return `${baseUrl}/welcome`;
+    },
+  },
+  debug: true,
+};


### PR DESCRIPTION
## Summary
- refactor NextAuth configuration into `lib/auth.ts`
- update API route to import auth options instead of exporting them
- adjust `ProtectedLayout` import

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685be45436e4832cadb951bbbc6a6f0c