### PR TITLE
Fix NextAuth session types

### DIFF
--- a/app-main/next-auth.d.ts
+++ b/app-main/next-auth.d.ts
@@ -1,0 +1,13 @@
+import "next-auth";
+
+declare module "next-auth" {
+  interface Session {
+    accessToken?: string;
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    accessToken?: string;
+  }
+}

--- a/app-main/tsconfig.json
+++ b/app-main/tsconfig.json
@@ -28,6 +28,7 @@
     "**/*.ts",
     "**/*.tsx",
     "next-env.d.ts",
+    "next-auth.d.ts",
     ".next/types/**/*.ts"
   ],
   "exclude": [


### PR DESCRIPTION
## Summary
- add type declarations for `Session.accessToken`
- include `next-auth.d.ts` in TS config

## Testing
- `npm ci` *(fails: network access needed)*

------
https://chatgpt.com/codex/tasks/task_e_685be7a9b644832cbbfe90a92c214dec