### PR TITLE
Fix session null check in welcome page

### DIFF
--- a/app-main/app/welcome/page copy 2.tsx
+++ b/app-main/app/welcome/page copy 2.tsx
@@ -22,7 +22,7 @@ export default function WelcomePage() {
     try {
       const res = await fetch(
         'https://api.dtuaitsoc.ngrok.dev/api/stealer-logs/dtu.dk/',
-        { headers: { Authorization: `Bearer ${session.accessToken}` } }
+        { headers: { Authorization: `Bearer ${session!.accessToken}` } }
       );
       if (!res.ok) throw new Error(`Fetch failed: ${res.status}`);
       setDebugResponse(await res.json());


### PR DESCRIPTION
## Summary
- assert `session` when building Authorization header to resolve TypeScript error

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685be97751cc832cbc0d565a57d332fb