### PR TITLE
Remove terms of use notice

### DIFF
--- a/app-main/app/components/HomePage.tsx
+++ b/app-main/app/components/HomePage.tsx
@@ -75,17 +75,6 @@ export default function HomePage() {
         </button>
       </div>
 
-      <p className="mt-2 text-xs text-gray-400">
-        Using Have I Been Pwned is subject to the{' '}
-        <a
-          className="underline"
-          href="https://haveibeenpwned.com/API/v3#TermsOfUse"
-          target="_blank"
-        >
-          terms of use
-        </a>
-      </p>
-
       {loading && <p className="mt-4 text-gray-300">Loading...</p>}
 
       {error && <p className="mt-4 text-red-600">Error: {error}</p>}


### PR DESCRIPTION
## Summary
- remove the "terms of use" message from the homepage

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685be9957790832c8a979c3369b1ab8a