### PR TITLE
Fix TypeScript build error

### DIFF
--- a/app-main/app/components/breach/BreachedAccount.tsx
+++ b/app-main/app/components/breach/BreachedAccount.tsx
@@ -88,7 +88,8 @@ export default function BreachCheckerPage() {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${session.accessToken}`,
+          // session is guaranteed above, so assert non-null
+          Authorization: `Bearer ${session!.accessToken}`,
         },
         body: JSON.stringify({ email }),
       });

--- a/app-main/app/welcome/page copy.tsx
+++ b/app-main/app/welcome/page copy.tsx
@@ -31,7 +31,8 @@ export default function WelcomePage() {
         "https://api.dtuaitsoc.ngrok.dev/api/stealer-logs/dtu.dk/",
         {
           headers: {
-            Authorization: `Bearer ${session.accessToken}`,
+            // session is checked above, so assert non-null here
+            Authorization: `Bearer ${session!.accessToken}`,
           },
         }
       );

--- a/app-main/app/welcome/page.tsx
+++ b/app-main/app/welcome/page.tsx
@@ -22,7 +22,12 @@ export default function WelcomePage() {
     try {
       const res = await fetch(
         'https://api.dtuaitsoc.ngrok.dev/api/stealer-logs/dtu.dk/',
-        { headers: { Authorization: `Bearer ${session.accessToken}` } }
+        {
+          headers: {
+            // session is validated above, so assert non-null
+            Authorization: `Bearer ${session!.accessToken}`,
+          },
+        }
       );
       if (!res.ok) throw new Error(`Fetch failed: ${res.status}`);
       setDebugResponse(await res.json());


### PR DESCRIPTION
## Summary
- assert non-null `session` when building auth headers

## Testing
- `npm run build` *(fails: next not found because dependencies are missing)*

------
https://chatgpt.com/codex/tasks/task_e_685bebac940c832ca10e5197e4cd287c