### PR TITLE
Handle 404 results

### DIFF
--- a/app-main/app/components/HomePage.tsx
+++ b/app-main/app/components/HomePage.tsx
@@ -33,6 +33,13 @@ export default function HomePage() {
         }
       );
 
+      if (res.status === 404) {
+        // A 404 means the email was not found in any breach
+        setResults([]);
+        setSearched(true);
+        return;
+      }
+
       if (!res.ok) {
         throw new Error(`Request failed with status ${res.status}`);
       }


### PR DESCRIPTION
## Summary
- treat 404 responses from the breach API as a successful search with no results
- keep the firework animation when there are no breaches

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bec02fcdc832caa4c044d9ff348f3