### PR TITLE
Add env variable for HIBP API base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # pwned-proxy-frontend
+
+## Configuration
+
+Copy `.env.local.example` to `.env.local` and adjust `NEXT_PUBLIC_HIBP_PROXY_URL`
+if you wish to use a different API location. This variable is read by the
+start page and the header link so it also works when deployed with Coolify.

--- a/app-main/.env.local.example
+++ b/app-main/.env.local.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_HIBP_PROXY_URL=https://api.haveibeenpwned.security.ait.dtu.dk/

--- a/app-main/app/components/Header.tsx
+++ b/app-main/app/components/Header.tsx
@@ -40,7 +40,10 @@ export default function Header() {
       {/* Right side: actions */}
       <div className="flex items-center space-x-4">
         <Link
-          href="https://api.haveibeenpwned.security.ait.dtu.dk/"
+          href={
+            process.env.NEXT_PUBLIC_HIBP_PROXY_URL ||
+            "https://api.haveibeenpwned.security.ait.dtu.dk/"
+          }
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/app-main/app/components/HomePage.tsx
+++ b/app-main/app/components/HomePage.tsx
@@ -26,8 +26,12 @@ export default function HomePage() {
     setSearched(false);
 
     try {
+      const apiBase =
+        process.env.NEXT_PUBLIC_HIBP_PROXY_URL ||
+        "https://api.haveibeenpwned.security.ait.dtu.dk/";
+
       const res = await fetch(
-        `https://api.haveibeenpwned.security.ait.dtu.dk/api/v3/breachedaccount/${encodeURIComponent(trimmedEmail)}`,
+        `${apiBase}api/v3/breachedaccount/${encodeURIComponent(trimmedEmail)}`,
         {
           headers: { accept: "application/json" },
         }


### PR DESCRIPTION
## Summary
- allow configuring the HaveIBeenPwned proxy URL via `NEXT_PUBLIC_HIBP_PROXY_URL`
- update start page and header link to use that variable
- provide `.env.local.example` with default value
- document configuration in README

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bed8bcbe8832ca3c41789b890d835