### PR TITLE
Add beta label in header

### DIFF
--- a/app-main/app/components/Header.tsx
+++ b/app-main/app/components/Header.tsx
@@ -32,8 +32,11 @@ export default function Header() {
     >
       {/* Left side: site logo or title */}
       <Link href="/">
-        <h1 className="text-lg font-bold text-tnLight-accent dark:text-tnStorm-accent">
+        <h1 className="text-lg font-bold text-tnLight-accent dark:text-tnStorm-accent flex items-center">
           Deic HaveIBeenPwned
+          <span className="ml-2 text-sm text-tnLight-red dark:text-tnStorm-green">
+            (Beta)
+          </span>
         </h1>
       </Link>
 


### PR DESCRIPTION
## Summary
- show a `(Beta)` label in the main header

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685cf9db7c4c832c981279b87c487c5f