### PR TITLE
Replace Deic text with logo in header

### DIFF
--- a/app-main/app/components/Header.tsx
+++ b/app-main/app/components/Header.tsx
@@ -33,7 +33,12 @@ export default function Header() {
       {/* Left side: site logo or title */}
       <Link href="/">
         <h1 className="text-lg font-bold text-tnLight-accent dark:text-tnStorm-accent flex items-center">
-          Deic HaveIBeenPwned
+          <img
+            src="https://www.deic.dk/themes/custom/deic/logo.svg"
+            alt="Deic logo"
+            className="h-6 mr-2"
+          />
+          HaveIBeenPwned
           <span className="ml-2 text-sm text-tnLight-red dark:text-tnStorm-green">
             (Beta)
           </span>


### PR DESCRIPTION
## Summary
- replace the "Deic" text in the header with the Deic logo

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d5153ad48832cb70cdefc40ef085d