### PR TITLE
Fetch live breach stats

### DIFF
--- a/app-main/app/api/site-stats/route.ts
+++ b/app-main/app/api/site-stats/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  try {
+    const breachesRes = await fetch('https://haveibeenpwned.com/api/v3/breaches', {
+      headers: {
+        'User-Agent': 'pwned-proxy-frontend',
+      },
+    });
+    if (!breachesRes.ok) {
+      return NextResponse.json(
+        { error: `Failed to fetch breaches: ${breachesRes.status}` },
+        { status: breachesRes.status }
+      );
+    }
+
+    const [breaches, homeHtml] = await Promise.all([
+      breachesRes.json(),
+      fetch('https://haveibeenpwned.com/', {
+        headers: {
+          'User-Agent': 'pwned-proxy-frontend',
+        },
+      }).then((r) => r.ok ? r.text() : '')
+    ]);
+    const totalWebsites = breaches.length;
+    const totalAccounts = breaches.reduce(
+      (sum: number, b: { PwnCount?: number }) => sum + (b.PwnCount || 0),
+      0
+    );
+
+    let totalPastes: number | null = null;
+    if (homeHtml) {
+      const pasteMatch = homeHtml.match(/([\d,]+)\s+Pastes/i);
+      if (pasteMatch) {
+        totalPastes = parseInt(pasteMatch[1].replace(/,/g, ''), 10);
+      }
+    }
+
+    return NextResponse.json({ totalWebsites, totalAccounts, totalPastes });
+  } catch (err) {
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/app-main/app/components/HomePage.tsx
+++ b/app-main/app/components/HomePage.tsx
@@ -21,6 +21,29 @@ export default function HomePage() {
   const [results, setResults] = useState<BreachData[] | null>(null);
   const [searched, setSearched] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [websiteCount, setWebsiteCount] = useState<number | null>(null);
+  const [accountCount, setAccountCount] = useState<number | null>(null);
+  const [pasteCount, setPasteCount] = useState<number | null>(null);
+
+  useEffect(() => {
+    const fetchStats = async () => {
+      try {
+        const res = await fetch('/api/site-stats');
+        if (!res.ok) {
+          throw new Error(`Failed to load stats: ${res.status}`);
+        }
+        const data = await res.json();
+        setWebsiteCount(data.totalWebsites);
+        setAccountCount(data.totalAccounts);
+        if (typeof data.totalPastes === 'number') {
+          setPasteCount(data.totalPastes);
+        }
+      } catch (err) {
+        console.log('Failed fetching stats', err);
+      }
+    };
+    fetchStats();
+  }, []);
 
 
   // Sign out handler
@@ -300,7 +323,7 @@ return (
           {/* 1: Blue gradient */}
           <div className="bg-white rounded-xl p-6 text-center shadow">
             <p className="text-3xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-blue-600">
-              892
+              {websiteCount !== null ? websiteCount.toLocaleString() : '—'}
             </p>
             <p className="text-gray-600 mt-1">Pwned Websites</p>
           </div>
@@ -308,7 +331,7 @@ return (
           {/* 2: Purple gradient */}
           <div className="bg-white rounded-xl p-6 text-center shadow">
             <p className="text-3xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-indigo-500 to-purple-500">
-              14,985,620
+              {accountCount !== null ? accountCount.toLocaleString() : '—'}
             </p>
             <p className="text-gray-600 mt-1">Pwned Accounts</p>
           </div>
@@ -316,7 +339,7 @@ return (
           {/* 3: Pink gradient */}
           <div className="bg-white rounded-xl p-6 text-center shadow">
             <p className="text-3xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-pink-500 to-pink-700">
-              32
+              {pasteCount !== null ? pasteCount.toLocaleString() : '—'}
             </p>
             <p className="text-gray-600 mt-1">Pastes</p>
           </div>


### PR DESCRIPTION
## Summary
- add API route to aggregate HaveIBeenPwned breach stats
- show live pwned website, account, and paste counts on the homepage
- log any errors when retrieving stats

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d521c8004832c91e980a4c10ea67d