### PR TITLE
Add passwords info page

### DIFF
--- a/app-main/app/components/Header.tsx
+++ b/app-main/app/components/Header.tsx
@@ -68,6 +68,20 @@ export default function Header() {
             API
           </button>
         </Link>
+        <Link href="/passwords">
+          <button
+            className="
+              bg-green-600
+              text-white
+              px-3 py-1
+              rounded-sm
+              hover:opacity-90
+              dark:bg-green-500
+            "
+          >
+            Passwords
+          </button>
+        </Link>
 
         {status === "loading" && <span className="text-sm">Loading...</span>}
 

--- a/app-main/app/passwords/page.tsx
+++ b/app-main/app/passwords/page.tsx
@@ -1,0 +1,23 @@
+export default function PasswordsPage() {
+  return (
+    <main className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Password Breach Checking APIs: HIBP and Alternatives</h1>
+      <p>
+        Data breaches have exposed billions of passwords, putting users at risk of account takeover through credential stuffing and other attacks. Services like Have I Been Pwned (HIBP) allow users to verify if a password appears in known breach corpuses.
+      </p>
+      <p>
+        HIBP's Pwned Passwords API implements a k-anonymity model. The client hashes the password locally with SHA-1 and sends only the first five hexadecimal characters to the endpoint <code>/range/&lt;prefix&gt;</code>. The response contains all matching suffixes and occurrence counts. If the client's full hash is in the list, the password is compromised.
+      </p>
+      <p>
+        The service is free, unauthenticated and heavily cached. Requests must include a <code>User-Agent</code> header and are performed over HTTPS.
+      </p>
+      <h2 className="text-xl font-semibold">Alternative Services</h2>
+      <p>
+        Several commercial APIs provide similar functionality with their own datasets and features. Examples include Enzoic, SpyCloud and DeHashed. These typically require an API key and may offer additional checks, such as username and password combinations or continuous monitoring.
+      </p>
+      <p>
+        Each service has different authentication requirements, rate limits and pricing models. When integrating them, consult the respective documentation for usage examples and constraints.
+      </p>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add new `Passwords` page summarizing password checking APIs
- link to the page in the site header

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d5883146c832c92b3ec675c4fc32f