### PR TITLE
Make paste stats dynamic

### DIFF
--- a/app-main/app/api/site-stats/route.ts
+++ b/app-main/app/api/site-stats/route.ts
@@ -21,7 +21,23 @@ export async function GET() {
       0
     );
 
-    return NextResponse.json({ totalWebsites, totalAccounts });
+    // Fetch paste statistics as well
+    const pasteRes = await fetch('https://haveibeenpwned.com/api/v3/pastes', {
+      headers: {
+        'User-Agent': 'pwned-proxy-frontend',
+      },
+    });
+    if (!pasteRes.ok) {
+      return NextResponse.json(
+        { error: `Failed to fetch pastes: ${pasteRes.status}` },
+        { status: pasteRes.status }
+      );
+    }
+
+    const pastes = await pasteRes.json();
+    const totalPastes = Array.isArray(pastes) ? pastes.length : 0;
+
+    return NextResponse.json({ totalWebsites, totalAccounts, totalPastes });
   } catch (err) {
     return NextResponse.json(
       { error: 'Internal server error' },

--- a/app-main/app/components/HomePage.tsx
+++ b/app-main/app/components/HomePage.tsx
@@ -23,6 +23,7 @@ export default function HomePage() {
   const [error, setError] = useState<string | null>(null);
   const [websiteCount, setWebsiteCount] = useState<number | null>(null);
   const [accountCount, setAccountCount] = useState<number | null>(null);
+  const [pasteCount, setPasteCount] = useState<number | null>(null);
 
   useEffect(() => {
     const fetchStats = async () => {
@@ -34,6 +35,9 @@ export default function HomePage() {
         const data = await res.json();
         setWebsiteCount(data.totalWebsites);
         setAccountCount(data.totalAccounts);
+        if (typeof data.totalPastes === 'number') {
+          setPasteCount(data.totalPastes);
+        }
       } catch (err) {
         console.error('Failed fetching stats', err);
       }
@@ -335,7 +339,7 @@ return (
           {/* 3: Pink gradient */}
           <div className="bg-white rounded-xl p-6 text-center shadow">
             <p className="text-3xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-pink-500 to-pink-700">
-              32
+              {pasteCount !== null ? pasteCount.toLocaleString() : '—'}
             </p>
             <p className="text-gray-600 mt-1">Pastes</p>
           </div>


### PR DESCRIPTION
## Summary
- fetch paste totals from HIBP API in site-stats route
- expose pasteCount in homepage stats box

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d58b9fb30832c8184abb2e59627b9