### PR TITLE
Add passwords info page

### DIFF
--- a/app-main/app/components/Header.tsx
+++ b/app-main/app/components/Header.tsx
@@ -68,6 +68,20 @@ export default function Header() {
             API
           </button>
         </Link>
+        <Link href="/passwords">
+          <button
+            className="
+              bg-green-600
+              text-white
+              px-3 py-1
+              rounded-sm
+              hover:opacity-90
+              dark:bg-green-500
+            "
+          >
+            Passwords
+          </button>
+        </Link>
 
         {status === "loading" && <span className="text-sm">Loading...</span>}
 

--- a/app-main/app/components/password/PasswordChecker.tsx
+++ b/app-main/app/components/password/PasswordChecker.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+
+async function sha1(message: string): Promise<string> {
+  const msgBuffer = new TextEncoder().encode(message);
+  const hashBuffer = await crypto.subtle.digest("SHA-1", msgBuffer);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("").toUpperCase();
+}
+
+export default function PasswordChecker() {
+  const [password, setPassword] = useState("");
+  const [result, setResult] = useState<number | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleCheck = async () => {
+    if (!password) return;
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      const hash = await sha1(password);
+      const prefix = hash.slice(0, 5);
+      const suffix = hash.slice(5);
+      const res = await fetch(`https://api.pwnedpasswords.com/range/${prefix}`, {
+        headers: {
+          "Add-Padding": "true",
+          "User-Agent": "pwned-proxy-frontend",
+        },
+      });
+      if (!res.ok) throw new Error("API request failed");
+      const text = await res.text();
+      const lines = text.split("\n");
+      let count: number | null = null;
+      for (const line of lines) {
+        const [hashSuffix, hits] = line.trim().split(":");
+        if (hashSuffix && hashSuffix.toUpperCase() === suffix) {
+          count = parseInt(hits, 10);
+          break;
+        }
+      }
+      setResult(count === null ? 0 : count);
+    } catch (err) {
+      setError((err as Error).message || "Error checking password");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center space-x-2">
+        <input
+          type="password"
+          placeholder="Enter password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="flex-1 px-3 py-2 border rounded text-black"
+        />
+        <button
+          onClick={handleCheck}
+          disabled={loading || !password}
+          className="px-4 py-2 bg-blue-600 text-white rounded disabled:bg-gray-500"
+        >
+          {loading ? "Checking..." : "Check"}
+        </button>
+      </div>
+      {error && <p className="text-red-600">{error}</p>}
+      {result !== null && (
+        result > 0 ? (
+          <p className="text-red-600">Password found {result.toLocaleString()} times in breaches.</p>
+        ) : (
+          <p className="text-green-600">Password not found in known breaches.</p>
+        )
+      )}
+      <p className="text-sm text-gray-500">
+        The password is hashed locally and only a partial hash is sent to the API for privacy.
+      </p>
+    </div>
+  );
+}

--- a/app-main/app/passwords/page.tsx
+++ b/app-main/app/passwords/page.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import PasswordChecker from "../components/password/PasswordChecker";
+
+export default function PasswordsPage() {
+  return (
+    <main className="p-6 space-y-6">
+      <h1 className="text-2xl font-bold">Password Breach Checking APIs: HIBP and Alternatives</h1>
+      <PasswordChecker />
+      <p>
+        Data breaches have exposed billions of passwords, putting users at risk of account takeover through credential stuffing and other attacks. Services like Have I Been Pwned (HIBP) allow users to verify if a password appears in known breach corpuses.
+      </p>
+      <p>
+        HIBP's Pwned Passwords API implements a k-anonymity model. The client hashes the password locally with SHA-1 and sends only the first five hexadecimal characters to the endpoint <code>/range/&lt;prefix&gt;</code>. The response contains all matching suffixes and occurrence counts. If the client's full hash is in the list, the password is compromised.
+      </p>
+      <p>
+        The service is free, unauthenticated and heavily cached. Requests must include a <code>User-Agent</code> header and are performed over HTTPS.
+      </p>
+      <h2 className="text-xl font-semibold">Alternative Services</h2>
+      <p>
+        Several commercial APIs provide similar functionality with their own datasets and features. Examples include Enzoic, SpyCloud and DeHashed. These typically require an API key and may offer additional checks, such as username and password combinations or continuous monitoring.
+      </p>
+      <p>
+        Each service has different authentication requirements, rate limits and pricing models. When integrating them, consult the respective documentation for usage examples and constraints.
+      </p>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add new `Passwords` page summarizing password checking APIs
- add interactive password checker using HIBP k-anonymity API
- link to the page in the site header

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d5883146c832c92b3ec675c4fc32f