### PR TITLE
Document analytics setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,18 @@
 Copy `.env.local.example` to `.env.local` and adjust `NEXT_PUBLIC_HIBP_PROXY_URL`
 if you wish to use a different API location. This variable is read by the
 start page and the header link so it also works when deployed with Coolify.
+
+### Google Analytics
+
+If you want to track visits with Google Analytics you can provide your
+measurement id through an environment variable. Add the variable
+`NEXT_PUBLIC_GA_MEASUREMENT_ID` to `.env.local`:
+
+```bash
+NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
+```
+
+Next.js exposes variables prefixed with `NEXT_PUBLIC_` to the browser during
+runtime. When this variable is defined the application will automatically load
+the GA script and start sending page view events. Remember to rebuild the app
+after changing environment variables.

--- a/app-main/.env.local.example
+++ b/app-main/.env.local.example
@@ -1,1 +1,2 @@
 NEXT_PUBLIC_HIBP_PROXY_URL=https://api.haveibeenpwned.security.ait.dtu.dk/
+NEXT_PUBLIC_GA_MEASUREMENT_ID=


### PR DESCRIPTION
## Summary
- explain how to configure Google Analytics via env variables
- include GA env var in `.env.local.example`

## Testing
- `npm ci` *(fails: cannot reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_685e7f2259c4832cb01c28971a3506be