### PR TITLE
Add HIBP API key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 ## Configuration
 
-Copy `.env.local.example` to `.env.local` and adjust `NEXT_PUBLIC_HIBP_PROXY_URL`
-if you wish to use a different API location. This variable is read by the
-start page and the header link so it also works when deployed with Coolify.
+Copy `.env.local.example` to `.env.local` and adjust the variables as needed.
+
+- `NEXT_PUBLIC_HIBP_PROXY_URL` sets the API location used by the start page and
+  header link.
+- `HIBP_API_KEY` provides the key required for server-side requests to the
+  Have I Been Pwned API.
+
+These variables ensure the application works locally and when deployed with
+Coolify.

--- a/app-main/.env.local.example
+++ b/app-main/.env.local.example
@@ -1,1 +1,2 @@
 NEXT_PUBLIC_HIBP_PROXY_URL=https://api.haveibeenpwned.security.ait.dtu.dk/
+HIBP_API_KEY=

--- a/app-main/app/api/site-stats/route.ts
+++ b/app-main/app/api/site-stats/route.ts
@@ -2,11 +2,16 @@ import { NextResponse } from 'next/server';
 
 export async function GET() {
   try {
-    const breachesRes = await fetch('https://haveibeenpwned.com/api/v3/breaches', {
+    const headers: Record<string, string> = {
+      'User-Agent': 'pwned-proxy-frontend',
+    };
 
-      headers: {
-        'User-Agent': 'pwned-proxy-frontend',
-      },
+    if (process.env.HIBP_API_KEY) {
+      headers['hibp-api-key'] = process.env.HIBP_API_KEY;
+    }
+
+    const breachesRes = await fetch('https://haveibeenpwned.com/api/v3/breaches', {
+      headers,
     });
     if (!breachesRes.ok) {
       return NextResponse.json(
@@ -31,9 +36,7 @@ export async function GET() {
 
     // Fetch paste statistics as well
     const pasteRes = await fetch('https://haveibeenpwned.com/api/v3/pastes', {
-      headers: {
-        'User-Agent': 'pwned-proxy-frontend',
-      },
+      headers,
     });
     if (!pasteRes.ok) {
       return NextResponse.json(


### PR DESCRIPTION
## Summary
- fetch the HIBP API with an optional `hibp-api-key` header
- document the new env var
- add placeholder to `.env.local.example`

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e7ea65c28832c94e3673c2f9810bb