### PR TITLE
Fix site stats fetch

### DIFF
--- a/app-main/.env.local.example
+++ b/app-main/.env.local.example
@@ -1,2 +1,3 @@
 NEXT_PUBLIC_HIBP_PROXY_URL=https://api.haveibeenpwned.security.ait.dtu.dk/
 NEXT_PUBLIC_GA_MEASUREMENT_ID=
+HIBP_API_KEY=

--- a/app-main/app/api/site-stats/route.ts
+++ b/app-main/app/api/site-stats/route.ts
@@ -3,9 +3,9 @@ import { NextResponse } from 'next/server';
 export async function GET() {
   try {
     const breachesRes = await fetch('https://haveibeenpwned.com/api/v3/breaches', {
-
       headers: {
         'User-Agent': 'pwned-proxy-frontend',
+        'hibp-api-key': process.env.HIBP_API_KEY ?? '',
       },
     });
     if (!breachesRes.ok) {
@@ -15,14 +15,7 @@ export async function GET() {
       );
     }
 
-    const [breaches, homeHtml] = await Promise.all([
-      breachesRes.json(),
-      fetch('https://haveibeenpwned.com/', {
-        headers: {
-          'User-Agent': 'pwned-proxy-frontend',
-        },
-      }).then((r) => r.ok ? r.text() : '')
-    ]);
+    const breaches = await breachesRes.json();
     const totalWebsites = breaches.length;
     const totalAccounts = breaches.reduce(
       (sum: number, b: { PwnCount?: number }) => sum + (b.PwnCount || 0),
@@ -33,6 +26,7 @@ export async function GET() {
     const pasteRes = await fetch('https://haveibeenpwned.com/api/v3/pastes', {
       headers: {
         'User-Agent': 'pwned-proxy-frontend',
+        'hibp-api-key': process.env.HIBP_API_KEY ?? '',
       },
     });
     if (!pasteRes.ok) {


### PR DESCRIPTION
## Summary
- fix site stats endpoint to send HIBP API key
- add example HIBP_API_KEY variable

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e9cc15d40832cbc05a5d57c00abe6