### PR TITLE
Add About page with subscribed domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,11 @@ Next.js exposes variables prefixed with `NEXT_PUBLIC_` to the browser during
 runtime. When this variable is defined the application will automatically load
 the GA script and start sending page view events. Remember to rebuild the app
 after changing environment variables.
+
+### Contact Email
+
+Set `NEXT_PUBLIC_CONTACT_EMAIL` in `.env.local` to display a contact address on the About page:
+
+```bash
+NEXT_PUBLIC_CONTACT_EMAIL=itsecurity@dtu.dk
+```

--- a/app-main/.env.local.example
+++ b/app-main/.env.local.example
@@ -1,3 +1,4 @@
 NEXT_PUBLIC_HIBP_PROXY_URL=https://api.haveibeenpwned.security.ait.dtu.dk/
 NEXT_PUBLIC_GA_MEASUREMENT_ID=
 HIBP_API_KEY=
+NEXT_PUBLIC_CONTACT_EMAIL=

--- a/app-main/app/about/page.tsx
+++ b/app-main/app/about/page.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export default function AboutPage() {
+  const [domains, setDomains] = useState<string[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch("/api/subscribed-domains");
+        if (!res.ok) throw new Error(`Failed to load domains: ${res.status}`);
+        const data = await res.json();
+        if (!Array.isArray(data) || data.length === 0) {
+          throw new Error("No domain list returned");
+        }
+        setDomains(data as string[]);
+      } catch (err) {
+        setError((err as Error).message);
+      }
+    };
+    load();
+  }, []);
+
+  if (error) {
+    return <div className="p-4 text-red-600">Error: {error}</div>;
+  }
+
+  if (!domains) {
+    return <div className="p-4">Loading…</div>;
+  }
+
+  return (
+    <main className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">About</h1>
+      <p>
+        Write contact {process.env.NEXT_PUBLIC_CONTACT_EMAIL} if you would like to get approved
+        access to your university!
+      </p>
+      <h2 className="text-xl font-semibold mt-4">Subscribed Universities</h2>
+      <ul className="list-disc pl-5">
+        {domains.map((d) => (
+          <li key={d}>{d}</li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/app-main/app/api/subscribed-domains/route.ts
+++ b/app-main/app/api/subscribed-domains/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+
+// University domains returned by the HIBP "subscribeddomains" endpoint
+const domains: string[] = [
+  'aau.dk',
+  'adm.aau.dk',
+  'adm.ku.dk',
+  'cbs.dk',
+  'cert.dk',
+  'deic.dk',
+  'dtu.dk',
+  'edu.kglakademi.dk',
+  'its.aau.dk',
+  'itu.dk',
+  'kglakademi.dk',
+  'nbi.dk',
+  'nbi.ku.dk',
+  'ruc.dk',
+  'srv.aau.dk',
+  'student.aau.dk',
+];
+
+export async function GET() {
+  return NextResponse.json(domains);
+}

--- a/app-main/app/components/Header.tsx
+++ b/app-main/app/components/Header.tsx
@@ -82,6 +82,20 @@ export default function Header() {
             Passwords
           </button>
         </Link>
+        <Link href="/about">
+          <button
+            className="
+              bg-gray-600
+              text-white
+              px-3 py-1
+              rounded-sm
+              hover:opacity-90
+              dark:bg-gray-500
+            "
+          >
+            About
+          </button>
+        </Link>
 
         {status === "loading" && <span className="text-sm">Loading...</span>}
 


### PR DESCRIPTION
## Summary
- create `/about` page listing subscribed domains and contact email
- provide API route for domains
- link About page from header
- document contact email env var
- update env example with contact email

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea44058a0832c96ca6a7e7551ac09