### PR TITLE
Fetch subscribed domains from HIBP

### DIFF
--- a/app-main/app/api/subscribed-domains/route.ts
+++ b/app-main/app/api/subscribed-domains/route.ts
@@ -1,25 +1,53 @@
 import { NextResponse } from 'next/server';
 
-// University domains returned by the HIBP "subscribeddomains" endpoint
-const domains: string[] = [
-  'aau.dk',
-  'adm.aau.dk',
-  'adm.ku.dk',
-  'cbs.dk',
-  'cert.dk',
-  'deic.dk',
-  'dtu.dk',
-  'edu.kglakademi.dk',
-  'its.aau.dk',
-  'itu.dk',
-  'kglakademi.dk',
-  'nbi.dk',
-  'nbi.ku.dk',
-  'ruc.dk',
-  'srv.aau.dk',
-  'student.aau.dk',
-];
-
+// Fetch the currently subscribed domains from the official HIBP API.
 export async function GET() {
-  return NextResponse.json(domains);
+  const apiKey = process.env.HIBP_API_KEY;
+
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: 'HIBP_API_KEY not configured' },
+      { status: 500 }
+    );
+  }
+
+  try {
+    const response = await fetch(
+      'https://haveibeenpwned.com/api/v3/subscribeddomains',
+      {
+        headers: {
+          'hibp-api-key': apiKey,
+          'user-agent': 'pwned-proxy-frontend',
+        },
+      }
+    );
+
+    const text = await response.text();
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: `HIBP API error: ${response.status}`, details: text },
+        { status: response.status }
+      );
+    }
+
+    const data = JSON.parse(text) as { DomainName?: string }[];
+    const domains = data
+      .map((d) => d.DomainName)
+      .filter((d): d is string => typeof d === 'string');
+
+    if (domains.length === 0) {
+      return NextResponse.json(
+        { error: 'No domains returned from HIBP API' },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json(domains);
+  } catch (err) {
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- fetch subscribed domains from the HIBP API rather than using a hardcoded list

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea89d189c832cbee6381e472798dd