### PR TITLE
Switch landing to About, add Email header link

### DIFF
--- a/app-main/app/components/Header.tsx
+++ b/app-main/app/components/Header.tsx
@@ -68,6 +68,20 @@ export default function Header() {
             API
           </button>
         </Link>
+        <Link href="/email">
+          <button
+            className="
+              bg-green-600
+              text-white
+              px-3 py-1
+              rounded-sm
+              hover:opacity-90
+              dark:bg-green-500
+            "
+          >
+            Email
+          </button>
+        </Link>
         <Link href="/passwords">
           <button
             className="

--- a/app-main/app/email/page.tsx
+++ b/app-main/app/email/page.tsx
@@ -1,7 +1,7 @@
 // app/page.tsx
 
 import type { Metadata } from "next";
-import AboutPage from "./about/page";
+import HomePage from "../components/HomePage";
 
 // (Optional) Next.js 13+ metadata
 // export const metadata: Metadata = {
@@ -10,5 +10,5 @@ import AboutPage from "./about/page";
 // };
 
 export default function Page() {
-  return <AboutPage />;
+  return <HomePage />;
 }


### PR DESCRIPTION
## Summary
- make the About page the landing page
- expose the previous start page at `/email`
- add `Email` button to header navigation

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eac727ea0832cbccf1740841bc303