### PR TITLE
Remove beta tag from header

### DIFF
--- a/app-main/app/components/Header.tsx
+++ b/app-main/app/components/Header.tsx
@@ -39,9 +39,6 @@ export default function Header() {
             className="h-6 mr-2"
           />
           HaveIBeenPwned
-          <span className="ml-2 text-sm text-tnLight-red dark:text-tnStorm-green">
-            (Beta)
-          </span>
         </h1>
       </Link>
 


### PR DESCRIPTION
## Summary
- remove the Beta text from the header

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eaec29d88832cacbcdb43f874cc82