### PR TITLE
Allow cross-site iframing

### DIFF
--- a/app-main/next.config.js
+++ b/app-main/next.config.js
@@ -1,0 +1,17 @@
+const nextConfig = {
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'X-Frame-Options',
+            value: 'ALLOWALL',
+          },
+        ],
+      },
+    ];
+  },
+};
+
+module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- add Next.js configuration to override `X-Frame-Options`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685eaed61de8832c8f44a9e17caefec4