### PR TITLE
Update start page messaging

### DIFF
--- a/app-main/app/about/page.tsx
+++ b/app-main/app/about/page.tsx
@@ -41,17 +41,15 @@ export default function AboutPage() {
         }}
       />
       <main className="relative z-10 max-w-3xl mx-auto px-4 py-16 text-center space-y-6">
-        <h1 className="text-5xl md:text-6xl font-bold">About</h1>
         <p className="text-lg text-gray-800">
-          If you work in the IT security department at one of these
-          universities, email
+          Contact
           <a
             href="mailto:itsecurity@dtu.dk"
             className="underline text-blue-600 ml-1"
           >
             itsecurity@dtu.dk
           </a>
-          to request access to the HaveIBeenPwned data we provide.
+          to request access.
         </p>
         <h2 className="text-xl font-semibold mt-6">Subscribed Universities</h2>
         <ul className="list-disc pl-5 text-left space-y-1">


### PR DESCRIPTION
## Summary
- simplify start page text and remove the large About heading

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb13e97b8832c894e68d2bf9ebbd8