### PR TITLE
Remove About from header

### DIFF
--- a/app-main/app/components/Header.tsx
+++ b/app-main/app/components/Header.tsx
@@ -93,20 +93,6 @@ export default function Header() {
             Passwords
           </button>
         </Link>
-        <Link href="/about">
-          <button
-            className="
-              bg-gray-600
-              text-white
-              px-3 py-1
-              rounded-sm
-              hover:opacity-90
-              dark:bg-gray-500
-            "
-          >
-            About
-          </button>
-        </Link>
 
         {status === "loading" && <span className="text-sm">Loading...</span>}
 


### PR DESCRIPTION
## Summary
- remove About button from the Header component

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb150c0a4832cbe4d528c49aedc91