### PR TITLE
Switch to new HIBP proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 ## Configuration
 
 Copy `.env.local.example` to `.env.local` and adjust `NEXT_PUBLIC_HIBP_PROXY_URL`
-if you wish to use a different API location. This variable is read by the
+if you wish to use a different API location. By default it points to
+`https://preview.api.haveibeenpwned.cert.dk/`. This variable is read by the
 start page and the header link so it also works when deployed with Coolify.
 
 ### Google Analytics

--- a/app-main/.env.local.example
+++ b/app-main/.env.local.example
@@ -1,4 +1,4 @@
-NEXT_PUBLIC_HIBP_PROXY_URL=https://api.haveibeenpwned.security.ait.dtu.dk/
+NEXT_PUBLIC_HIBP_PROXY_URL=https://preview.api.haveibeenpwned.cert.dk/
 NEXT_PUBLIC_GA_MEASUREMENT_ID=
 HIBP_API_KEY=
 NEXT_PUBLIC_CONTACT_EMAIL=

--- a/app-main/app/api/public-breach-check/route.ts
+++ b/app-main/app/api/public-breach-check/route.ts
@@ -5,8 +5,11 @@ export async function POST(request: NextRequest) {
     const { email } = await request.json();
 
     // Server-side call to the Django API without requiring Authorization
+    const baseUrl =
+      process.env.NEXT_PUBLIC_HIBP_PROXY_URL ||
+      'https://preview.api.haveibeenpwned.cert.dk';
     const response = await fetch(
-      `https://api.haveibeenpwned.security.ait.dtu.dk/api/v3/breachedaccount/${encodeURIComponent(email)}/`,
+      `${baseUrl}/api/v3/breachedaccount/${encodeURIComponent(email)}/`,
       {
         method: 'GET',
         headers: {

--- a/app-main/app/components/Header.tsx
+++ b/app-main/app/components/Header.tsx
@@ -47,7 +47,7 @@ export default function Header() {
         <Link
           href={
             process.env.NEXT_PUBLIC_HIBP_PROXY_URL ||
-            "https://api.haveibeenpwned.security.ait.dtu.dk/"
+            'https://preview.api.haveibeenpwned.cert.dk/'
           }
           target="_blank"
           rel="noopener noreferrer"

--- a/app-main/app/components/HomePage.tsx
+++ b/app-main/app/components/HomePage.tsx
@@ -70,7 +70,9 @@ export default function HomePage() {
       console.log('=== DEBUG: Starting breach check ===');
       console.log('Email:', trimmedEmail);
 
-      const apiUrl = `https://api.haveibeenpwned.security.ait.dtu.dk/api/v3/breachedaccount/${encodeURIComponent(trimmedEmail)}/`;
+      const baseUrl = process.env.NEXT_PUBLIC_HIBP_PROXY_URL ||
+        'https://preview.api.haveibeenpwned.cert.dk';
+      const apiUrl = `${baseUrl}/api/v3/breachedaccount/${encodeURIComponent(trimmedEmail)}/`;
       
       const response = await fetch(apiUrl, {
         method: 'GET',

--- a/app-main/app/welcome/page copy3.tsx
+++ b/app-main/app/welcome/page copy3.tsx
@@ -104,7 +104,10 @@ export default function WelcomePage() {
         {/* Scrollable “window” box */}
         <div className="border border-gray-700 rounded overflow-auto h-80">
           <iframe
-            src="https://api.haveibeenpwned.security.ait.dtu.dk/"
+            src={
+              process.env.NEXT_PUBLIC_HIBP_PROXY_URL ||
+              'https://preview.api.haveibeenpwned.cert.dk/'
+            }
             title="Backend API Preview"
             className="w-full min-h-full"
           />
@@ -112,7 +115,10 @@ export default function WelcomePage() {
 
         {/* Click-out link */}
         <a
-          href="https://api.haveibeenpwned.security.ait.dtu.dk/"
+          href={
+            process.env.NEXT_PUBLIC_HIBP_PROXY_URL ||
+            'https://preview.api.haveibeenpwned.cert.dk/'
+          }
           target="_blank"
           rel="noopener noreferrer"
           className="inline-block mt-2 text-[#9ece6a] hover:underline"

--- a/app-main/app/welcome/page.tsx
+++ b/app-main/app/welcome/page.tsx
@@ -111,7 +111,10 @@ export default function WelcomePage() {
         {/* Scrollable “window” box */}
         <div className="border border-gray-700 rounded overflow-auto h-80">
           <iframe
-            src="https://api.haveibeenpwned.security.ait.dtu.dk/"
+            src={
+              process.env.NEXT_PUBLIC_HIBP_PROXY_URL ||
+              'https://preview.api.haveibeenpwned.cert.dk/'
+            }
             title="Backend API Preview"
             className="w-full min-h-full"
           />
@@ -119,7 +122,10 @@ export default function WelcomePage() {
 
         {/* Click-out link */}
         <a
-          href="https://api.haveibeenpwned.security.ait.dtu.dk/"
+          href={
+            process.env.NEXT_PUBLIC_HIBP_PROXY_URL ||
+            'https://preview.api.haveibeenpwned.cert.dk/'
+          }
           target="_blank"
           rel="noopener noreferrer"
           className="inline-block mt-2 text-[#9ece6a] hover:underline"

--- a/app-main/lib/api-config.ts
+++ b/app-main/lib/api-config.ts
@@ -1,5 +1,7 @@
 export const API_CONFIG = {
-  BASE_URL: 'https://api.haveibeenpwned.security.ait.dtu.dk',
+  BASE_URL:
+    process.env.NEXT_PUBLIC_HIBP_PROXY_URL ||
+    'https://preview.api.haveibeenpwned.cert.dk',
   ENDPOINTS: {
     // Endpoints that require email + apikey
     BREACHED_ACCOUNT: '/breached-account',           // GET 5) Breached Account (by email)

--- a/app-main/public/haveibeenpwned.deic.dk.postman_collection_v2.json
+++ b/app-main/public/haveibeenpwned.deic.dk.postman_collection_v2.json
@@ -17,7 +17,7 @@
 					}
 				],
 				"url": {
-					"raw": "https://api.haveibeenpwned.security.ait.dtu.dk/api/v3/subscribeddomains",
+					"raw": "https://preview.api.haveibeenpwned.cert.dk/api/v3/subscribeddomains",
 					"protocol": "https",
 					"host": [
 						"api",
@@ -47,7 +47,7 @@
 					}
 				],
 				"url": {
-					"raw": "https://api.haveibeenpwned.security.ait.dtu.dk/api/v3/subscription/status",
+					"raw": "https://preview.api.haveibeenpwned.cert.dk/api/v3/subscription/status",
 					"protocol": "https",
 					"host": [
 						"api",
@@ -78,7 +78,7 @@
 					}
 				],
 				"url": {
-					"raw": "https://api.haveibeenpwned.security.ait.dtu.dk/api/v3/breacheddomain/dtu.dk",
+					"raw": "https://preview.api.haveibeenpwned.cert.dk/api/v3/breacheddomain/dtu.dk",
 					"protocol": "https",
 					"host": [
 						"api",
@@ -109,7 +109,7 @@
 					}
 				],
 				"url": {
-					"raw": "https://api.haveibeenpwned.security.ait.dtu.dk/api/v3/dataclasses",
+					"raw": "https://preview.api.haveibeenpwned.cert.dk/api/v3/dataclasses",
 					"protocol": "https",
 					"host": [
 						"api",
@@ -139,7 +139,7 @@
 					}
 				],
 				"url": {
-					"raw": "https://api.haveibeenpwned.security.ait.dtu.dk/api/v3/breachedaccount/juva@dtu.dk",
+					"raw": "https://preview.api.haveibeenpwned.cert.dk/api/v3/breachedaccount/juva@dtu.dk",
 					"protocol": "https",
 					"host": [
 						"api",
@@ -170,7 +170,7 @@
 					}
 				],
 				"url": {
-					"raw": "https://api.haveibeenpwned.security.ait.dtu.dk/api/v3/breaches",
+					"raw": "https://preview.api.haveibeenpwned.cert.dk/api/v3/breaches",
 					"protocol": "https",
 					"host": [
 						"api",
@@ -200,7 +200,7 @@
 					}
 				],
 				"url": {
-					"raw": "https://api.haveibeenpwned.security.ait.dtu.dk/api/v3/breach/Adobe",
+					"raw": "https://preview.api.haveibeenpwned.cert.dk/api/v3/breach/Adobe",
 					"protocol": "https",
 					"host": [
 						"api",
@@ -231,7 +231,7 @@
 					}
 				],
 				"url": {
-					"raw": "https://api.haveibeenpwned.security.ait.dtu.dk/api/v3/pasteaccount/mpark@dtu.dk",
+					"raw": "https://preview.api.haveibeenpwned.cert.dk/api/v3/pasteaccount/mpark@dtu.dk",
 					"protocol": "https",
 					"host": [
 						"api",
@@ -263,7 +263,7 @@
 					}
 				],
 				"url": {
-					"raw": "https://api.haveibeenpwned.security.ait.dtu.dk/api/v3/stealerlogsbyemaildomain/ruc.dk",
+					"raw": "https://preview.api.haveibeenpwned.cert.dk/api/v3/stealerlogsbyemaildomain/ruc.dk",
 					"protocol": "https",
 					"host": [
 						"api",
@@ -294,7 +294,7 @@
 					}
 				],
 				"url": {
-					"raw": "https://api.haveibeenpwned.security.ait.dtu.dk/api/v3/stealerlogsbyemail/rele@dtu.dk",
+					"raw": "https://preview.api.haveibeenpwned.cert.dk/api/v3/stealerlogsbyemail/rele@dtu.dk",
 					"protocol": "https",
 					"host": [
 						"api",
@@ -325,7 +325,7 @@
 					}
 				],
 				"url": {
-					"raw": "https://api.haveibeenpwned.security.ait.dtu.dk/api/v3/stealerlogsbywebsitedomain/dtu.dk",
+					"raw": "https://preview.api.haveibeenpwned.cert.dk/api/v3/stealerlogsbywebsitedomain/dtu.dk",
 					"protocol": "https",
 					"host": [
 						"api",
@@ -351,7 +351,7 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "https://api.haveibeenpwned.security.ait.dtu.dk/range/5BAA6",
+					"raw": "https://preview.api.haveibeenpwned.cert.dk/range/5BAA6",
 					"protocol": "https",
 					"host": [
 						"api",


### PR DESCRIPTION
## Summary
- default NEXT_PUBLIC_HIBP_PROXY_URL points to the new preview API
- read proxy URL from env var across the app
- update sample Postman collection

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b9e54bc28832c9a049866fdb195de