### PR TITLE
Fix HIBP email search

### DIFF
--- a/app-main/app/api/public-breach-check/route.ts
+++ b/app-main/app/api/public-breach-check/route.ts
@@ -9,7 +9,7 @@ export async function POST(request: NextRequest) {
       process.env.NEXT_PUBLIC_HIBP_PROXY_URL ||
       'https://preview.api.haveibeenpwned.cert.dk';
     const response = await fetch(
-      `${baseUrl}/api/v3/breachedaccount/${encodeURIComponent(email)}/`,
+      `${baseUrl}/api/v3/breachedaccount/${encodeURIComponent(email)}/?includeUnverified=true`,
       {
         method: 'GET',
         headers: {

--- a/app-main/app/components/HomePage.tsx
+++ b/app-main/app/components/HomePage.tsx
@@ -72,7 +72,7 @@ export default function HomePage() {
 
       const baseUrl = process.env.NEXT_PUBLIC_HIBP_PROXY_URL ||
         'https://preview.api.haveibeenpwned.cert.dk';
-      const apiUrl = `${baseUrl}/api/v3/breachedaccount/${encodeURIComponent(trimmedEmail)}/`;
+      const apiUrl = `${baseUrl}/api/v3/breachedaccount/${encodeURIComponent(trimmedEmail)}/?includeUnverified=true`;
       
       const response = await fetch(apiUrl, {
         method: 'GET',


### PR DESCRIPTION
## Summary
- include unverified results when querying the HIBP proxy

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bacad7810832cb27645a941f3aa55