### PR TITLE
Fix HIBP email search

### DIFF
--- a/app-main/app/api/public-breach-check/route.ts
+++ b/app-main/app/api/public-breach-check/route.ts
@@ -5,18 +5,17 @@ export async function POST(request: NextRequest) {
     const { email } = await request.json();
 
     // Server-side call to the Django API without requiring Authorization
-    const baseUrl =
+    const baseUrl = (
       process.env.NEXT_PUBLIC_HIBP_PROXY_URL ||
-      'https://preview.api.haveibeenpwned.cert.dk';
-    const response = await fetch(
-      `${baseUrl}/api/v3/breachedaccount/${encodeURIComponent(email)}/`,
-      {
-        method: 'GET',
-        headers: {
-          accept: 'application/json',
-        },
-      }
-    );
+      'https://preview.api.haveibeenpwned.cert.dk'
+    ).replace(/\/$/, '');
+    const apiUrl = `${baseUrl}/api/v3/breachedaccount/${encodeURIComponent(email)}?includeUnverified=true`;
+    const response = await fetch(apiUrl, {
+      method: 'GET',
+      headers: {
+        accept: 'application/json',
+      },
+    });
 
 
     console.log('=== SERVER: Backend response ===');

--- a/app-main/app/components/HomePage.tsx
+++ b/app-main/app/components/HomePage.tsx
@@ -70,9 +70,9 @@ export default function HomePage() {
       console.log('=== DEBUG: Starting breach check ===');
       console.log('Email:', trimmedEmail);
 
-      const baseUrl = process.env.NEXT_PUBLIC_HIBP_PROXY_URL ||
-        'https://preview.api.haveibeenpwned.cert.dk';
-      const apiUrl = `${baseUrl}/api/v3/breachedaccount/${encodeURIComponent(trimmedEmail)}/`;
+      const baseUrl = (process.env.NEXT_PUBLIC_HIBP_PROXY_URL ||
+        'https://preview.api.haveibeenpwned.cert.dk').replace(/\/$/, '');
+      const apiUrl = `${baseUrl}/api/v3/breachedaccount/${encodeURIComponent(trimmedEmail)}?includeUnverified=true`;
       
       const response = await fetch(apiUrl, {
         method: 'GET',


### PR DESCRIPTION
## Summary
- include unverified results when querying the HIBP proxy
- strip trailing slash from HIBP URL and remove extra slash before query

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bacad7810832cb27645a941f3aa55