### PR TITLE
Fix clearing password field after check

### DIFF
--- a/app-main/app/components/password/PasswordChecker.tsx
+++ b/app-main/app/components/password/PasswordChecker.tsx
@@ -105,7 +105,8 @@ export default function PasswordChecker() {
     } finally {
       setLoading(false);
       setPassword("");
-      setDisplay("\u2022".repeat(original.length));
+      // Clear the masked input after checking so users can easily enter a new password
+      setDisplay("");
     }
   };
 


### PR DESCRIPTION
## Summary
- reset the password input after checking so the old value can be deleted easily

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bb8467b48832cb13774e14245b5f4